### PR TITLE
Add complete French SoundCloud locale

### DIFF
--- a/locale/fr-fr/skill.json
+++ b/locale/fr-fr/skill.json
@@ -1,0 +1,7 @@
+{
+  "name": "SoundCloud",
+  "examples": [
+    "lance piratech sur soundcloud",
+    "lance piratech nuclear chill sur soundcloud"
+  ]
+}

--- a/locale/fr-fr/skill.json
+++ b/locale/fr-fr/skill.json
@@ -1,7 +1,7 @@
 {
   "name": "SoundCloud",
   "examples": [
-    "lance piratech sur soundcloud",
-    "lance piratech nuclear chill sur soundcloud"
+    "joue piratech sur soundcloud",
+    "joue piratech nuclear chill sur soundcloud"
   ]
 }

--- a/locale/fr-fr/soundcloud.voc
+++ b/locale/fr-fr/soundcloud.voc
@@ -1,6 +1,4 @@
-en nuage sonore
-in soundcloud
-son nuage
+sound cloud
 soundcloud
-sur le nuage sonore
+sur sound cloud
 sur soundcloud

--- a/locale/fr-fr/soundcloud_skill.voc
+++ b/locale/fr-fr/soundcloud_skill.voc
@@ -1,5 +1,2 @@
-# auto translated from en-us to fr-fr
-habileté du nuage
-soundcloud
-son nuage
-habileté sonore
+(soundcloud|sound cloud)
+(compétence|skill) (soundcloud|sound cloud)

--- a/locale/fr-fr/soundcloud_skill.voc
+++ b/locale/fr-fr/soundcloud_skill.voc
@@ -1,2 +1,1 @@
 (soundcloud|sound cloud)
-(compétence|skill) (soundcloud|sound cloud)

--- a/translations/fr-fr/vocabs.json
+++ b/translations/fr-fr/vocabs.json
@@ -1,10 +1,8 @@
 {
-    "soundcloud.voc": [
-        "sur soundcloud",
-        "in soundcloud",
-        "en nuage sonore",
-        "son nuage",
-        "sur le nuage sonore",
-        "soundcloud"
-    ]
+  "soundcloud.voc": [
+    "soundcloud",
+    "sound cloud",
+    "sur soundcloud",
+    "sur sound cloud"
+  ]
 }


### PR DESCRIPTION
## Summary
- add the missing `locale/fr-fr/skill.json`
- clean the French SoundCloud vocabulary so it sounds natural and stays brand-explicit
- fix the French `soundcloud_skill.voc` entries used for skill invocation

## Testing
- `git diff --check`
- parsed `translations/fr-fr/vocabs.json`
- verified `fr-fr` file coverage now matches `en-us`
